### PR TITLE
Add upgrade pip and --no-cache-dir option

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,6 @@ RUN \
   apk update && \
   apk add bash py-pip && \
   apk add --virtual=build gcc libffi-dev musl-dev openssl-dev python-dev make && \
-  pip install azure-cli && \
-  apk del --purge build 
+  pip --no-cache-dir install -U pip && \
+  pip --no-cache-dir install azure-cli && \
+  apk del --purge build


### PR DESCRIPTION
I encounted this error in `pip install azure-cli`.

```
...
Collecting cryptography (from azure-cli-botservice->azure-cli)
  Downloading https://files.pythonhosted.org/packages/f3/39/d3904df7c56f8654691c4ae1bdb270c1c9220d6da79bd3b1fbad91afd0e1/cryptography-2.4.2.tar.gz (468kB)
    100% |████████████████████████████████| 471kB 677kB/s 
  Could not find a version that satisfies the requirement cffi!=1.11.3,>=1.7 (from versions: )
No matching distribution found for cffi!=1.11.3,>=1.7
```

This error was generated by pip version. So, I added upgrade pip command.

(I was confirming that cffi==1.11.5 is installed by dependencies. this code: `pip install cffi`)

Also, reduced the docker image by about 30MB using "--no-cache-dir"
